### PR TITLE
disable OVERFLOW checks for NumberOfTrailingZeros() purepascal version

### DIFF
--- a/Source/Velthuis.Numerics.pas
+++ b/Source/Velthuis.Numerics.pas
@@ -561,10 +561,20 @@ asm
 end;
 {$ELSE PUREPASCAL}
 begin
+{$IFOPT Q+}
+  {$DEFINE OVERFLOW_ON}
+  {$Q-}
+{$ELSE}
+  {$UNDEF OVERFLOW_ON}
+{$ENDIF}  
   if U = 0 then
     Result := 32
   else
     Result := NTZDeBruijn32[((U and (-Integer(U))) * NTZDeBruijn32Mult) shr 27];
+{$IFDEF OVERFLOW_ON}
+  {$Q+}
+  {$UNDEF OVERFLOW_ON}
+{$ENDIF}
 end;
 {$IFEND PUREPASCAL}
 


### PR DESCRIPTION
Hi Rudy,

I found that this pure pascal version which is used on Linux64 crashes when OVERFLOWCHECKS are turned on. Are you able to verify that this is expected and that overflowchecks should be turned off?

The unit does not seem to be explicit about whether overflowchecks be enabled or not is this something you have considered? In any case i've made it conditionally turn it off and on again only if it was turned off.

Thanks for reviewing.

Jared